### PR TITLE
Use CLI args to create model

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,7 +12,7 @@ args = [
     'run',
 	'--release',
 	'--',
-	'--runtime', '30s',
+	'--duration', '30s',
 	'--output-path', 'output/frames',
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,7 +13,7 @@ args = [
 	'--release',
 	'--',
 	'--duration', '30s',
-	'--output-dir', 'output/frames',
+	'--output-dir', 'output',
 ]
 
 [tasks.stitch-video]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,7 +13,7 @@ args = [
 	'--release',
 	'--',
 	'--duration', '30s',
-	'--output-path', 'output/frames',
+	'--output-dir', 'output/frames',
 ]
 
 [tasks.stitch-video]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,23 +8,18 @@ use nannou::prelude::*;
 use humantime::parse_duration;
 use structopt::StructOpt;
 
-const RUNTIME_SECONDS: u64 = 60;
-
 const OUTPUT_DIR: &'static str = "output/frames";
 
 #[derive(Debug, StructOpt)]
-struct Opt {
+struct Opts {
     #[structopt(long, parse(try_from_str = parse_duration))]
-    runtime: Option<time::Duration>,
+    duration: Option<time::Duration>,
 
     #[structopt(long, parse(from_os_str))]
     output_path: Option<path::PathBuf>,
 }
 
 fn main() {
-    let opts = Opt::from_args();
-    println!("{:?}", opts);
-
     fs::remove_dir_all(OUTPUT_DIR).unwrap_or_else(|_| println!("Could not remove output dir"));
     fs::create_dir_all(OUTPUT_DIR).expect("Could not create output dir");
 
@@ -36,7 +31,7 @@ fn main() {
 }
 
 struct Model {
-    runtime: Option<time::Duration>,
+    duration: Option<time::Duration>,
 
     // rotation of the object
     // [0, 2PI]
@@ -53,10 +48,12 @@ struct Model {
 }
 
 fn model(app: &App) -> Model {
+    let opts = Opts::from_args();
+
     app.set_loop_mode(LoopMode::rate_fps(60.));
 
     Model {
-        runtime: Some(time::Duration::new(RUNTIME_SECONDS, 0)), // TODO: How do I get a CLI arg here?
+        duration: opts.duration,
         rot: 0.,
         clones: 0,
         spawn_rate: 1,
@@ -66,8 +63,8 @@ fn model(app: &App) -> Model {
 }
 
 fn update(app: &App, model: &mut Model, update: Update) {
-    if let Some(runtime) = model.runtime {
-        if update.since_start > runtime {
+    if let Some(duration) = model.duration {
+        if update.since_start > duration {
             return app.quit();
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,21 +8,16 @@ use nannou::prelude::*;
 use humantime::parse_duration;
 use structopt::StructOpt;
 
-const OUTPUT_DIR: &'static str = "output/frames";
-
 #[derive(Debug, StructOpt)]
 struct Opts {
     #[structopt(long, parse(try_from_str = parse_duration))]
     duration: Option<time::Duration>,
 
     #[structopt(long, parse(from_os_str))]
-    output_path: Option<path::PathBuf>,
+    output_dir: Option<path::PathBuf>,
 }
 
 fn main() {
-    fs::remove_dir_all(OUTPUT_DIR).unwrap_or_else(|_| println!("Could not remove output dir"));
-    fs::create_dir_all(OUTPUT_DIR).expect("Could not create output dir");
-
     nannou::app(model)
         .update(update)
         .simple_window(view)
@@ -32,6 +27,7 @@ fn main() {
 
 struct Model {
     duration: Option<time::Duration>,
+    output_dir: Option<path::PathBuf>,
 
     // rotation of the object
     // [0, 2PI]
@@ -50,10 +46,16 @@ struct Model {
 fn model(app: &App) -> Model {
     let opts = Opts::from_args();
 
+    if let Some(dir) = &opts.output_dir {
+        fs::remove_dir_all(dir).unwrap_or_else(|_| println!("Could not remove output dir"));
+        fs::create_dir_all(dir).expect("Could not create output dir");
+    }
+
     app.set_loop_mode(LoopMode::rate_fps(60.));
 
     Model {
         duration: opts.duration,
+        output_dir: opts.output_dir,
         rot: 0.,
         clones: 0,
         spawn_rate: 1,
@@ -137,16 +139,13 @@ fn view(app: &App, model: &Model, frame: Frame) {
 
     draw.to_frame(app, &frame).unwrap();
 
-    // Capture the frame for stitching together later.
-    let file_path = captured_frame_path(app, &frame);
-    app.main_window().capture_frame(file_path);
+    if let Some(dir) = &model.output_dir {
+        // Capture the frame for stitching together later.
+        let file_path = captured_frame_path(dir, &frame);
+        app.main_window().capture_frame(file_path);
+    }
 }
 
-fn captured_frame_path(app: &App, frame: &Frame) -> std::path::PathBuf {
-    app.project_path()
-        .expect("failed to locate `project_path`")
-        .join(OUTPUT_DIR)
-        // Use the frame number the a filename.
-        .join(frame.nth().to_string())
-        .with_extension("png")
+fn captured_frame_path(dir: &path::PathBuf, frame: &Frame) -> std::path::PathBuf {
+    dir.join(frame.nth().to_string()).with_extension("png")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,5 +147,7 @@ fn view(app: &App, model: &Model, frame: Frame) {
 }
 
 fn captured_frame_path(dir: &path::PathBuf, frame: &Frame) -> std::path::PathBuf {
-    dir.join(frame.nth().to_string()).with_extension("png")
+    dir.join("frames")
+        .join(frame.nth().to_string())
+        .with_extension("png")
 }


### PR DESCRIPTION
Continuing from #5 and on our way to #3, this threads the CLI args through to the model.  (What I was missing in that late-night PR was that we could parse the options _in_ the model function.)

This makes frame output a "mode": it only writes the frame PNGs if `--output-dir` is set.
